### PR TITLE
Fix GPU assignment and using Scipion's planner

### DIFF
--- a/membrain/__init__.py
+++ b/membrain/__init__.py
@@ -56,7 +56,7 @@ class Plugin(pwem.Plugin):
         """ Return the full command to run a MemBrain program. """
         cmd = cls.getCondaActivationCmd() + " "
         cmd += cls.getMemBrainSegActivation()
-        cmd += " && membrain "
+        cmd += " && CUDA_VISIBLE_DEVICES=%(GPU)s membrain "
         return cmd
 
     @classmethod

--- a/membrain/protocols/protocol_membrain_seg.py
+++ b/membrain/protocols/protocol_membrain_seg.py
@@ -132,23 +132,14 @@ class ProtMemBrainSeg(EMProtocol):
     # -------------------------- INSERT steps functions -----------------------
     def _insertAllSteps(self):
 
-        # Scipion's built-in GPU per-thread assignment seems broken so we need to do this:
-        gpus = getattr(self, GPU_LIST).getListFromValues()
-        print(gpus)
-        n_gpus = len(gpus)
-
         deps = []
-        for i, tomo in enumerate(self.inTomograms.get()):
-            gpu_idx = i % n_gpus
+        for tomo in self.inTomograms.get():
             deps.append(self._insertFunctionStep(self.runMemBrainSeg,
-                        tomo.getFileName(), gpus[gpu_idx], prerequisites=[]))
+                        tomo.getFileName(), prerequisites=[]))
 
         self._insertFunctionStep(self.createOutputStep, prerequisites=deps)
 
-    def runMemBrainSeg(self, tomoFile: str, gpuID: int):
-
-        gpuAssignment = "CUDA_VISIBLE_DEVICES=" + str(gpuID) + "; "
-
+    def runMemBrainSeg(self, tomoFile: str):
         tomoBaseName = removeBaseExt(tomoFile)
 
         # Arguments to the membrain command defined in the plugin initialization:
@@ -177,7 +168,7 @@ class ProtMemBrainSeg(EMProtocol):
             
         args += " " + self.additionalArgs.get()
 
-        self.runJob(gpuAssignment + Plugin.getMemBrainSegCmd(), args)
+        self.runJob(Plugin.getMemBrainSegCmd(), args)
 
         modelBaseName = os.path.basename(Plugin.getMemBrainSegModelPath())
         OutputFile = self.getWorkingDir() + '/' + OUTPUT_DIR + '/' + tomoBaseName + \

--- a/membrain/protocols/protocol_membrain_seg.py
+++ b/membrain/protocols/protocol_membrain_seg.py
@@ -60,10 +60,8 @@ class ProtMemBrainSeg(EMProtocol):
 
     tomoMaskList = []
     tomoProbMapList = []
-
-    def __init__(self, **args):
-        EMProtocol.__init__(self, **args)
-        self.stepsExecutionMode = STEPS_PARALLEL
+    
+    stepsExecutionMode = STEPS_PARALLEL
 
     # -------------------------- DEFINE param functions ----------------------
     def _defineParams(self, form):
@@ -135,9 +133,9 @@ class ProtMemBrainSeg(EMProtocol):
         deps = []
         for tomo in self.inTomograms.get():
             deps.append(self._insertFunctionStep(self.runMemBrainSeg,
-                        tomo.getFileName(), prerequisites=[]))
+                        tomo.getFileName(), prerequisites=[], needsGPU=True))
 
-        self._insertFunctionStep(self.createOutputStep, prerequisites=deps)
+        self._insertFunctionStep(self.createOutputStep, prerequisites=deps, needsGPU=False)
 
     def runMemBrainSeg(self, tomoFile: str):
         tomoBaseName = removeBaseExt(tomoFile)


### PR DESCRIPTION
The missing `export` command before `CUDA_VISIBLE_DEVICES` prevented from correctly using the assigned GPU. As `export` is not universal, we have added the variable in par with the membrain call, so that export is not required. In addition, we have adapted the code to use Scipion's GPU allocation system, which is now stable.

Note: Scipion needs to be updated for this to work